### PR TITLE
Explicit envs for prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# fm-dubai-colonel-api
+Fork of https://github.com/redbadger/colonel-api

--- a/app.rb
+++ b/app.rb
@@ -8,7 +8,7 @@ uri = URI(ENV['ELASTICSEARCH_URI'] || ENV['COLONELAPI_ELASTICSEARCH_1_PORT'])
 uri.scheme = 'http' # is tcp otherwise
 Colonel.config.elasticsearch_uri = uri.to_s
 
-uri = URI(ENV['REDIS'] || ENV['COLONELAPI_REDIS_1_PORT'])
+uri = URI(ENV['REDIS_URI'] || ENV['COLONELAPI_REDIS_1_PORT'])
 redis_backend = Rugged::Redis::Backend.new(host: uri.host, port: uri.port)
 Colonel.config.rugged_backend = redis_backend
 

--- a/app.rb
+++ b/app.rb
@@ -4,11 +4,11 @@ require 'rugged-redis'
 require 'pry'
 require 'json'
 
-uri = URI(ENV['COLONELAPI_ELASTICSEARCH_1_PORT'])
+uri = URI(ENV['ELASTICSEARCH_URI'] || ENV['COLONELAPI_ELASTICSEARCH_1_PORT'])
 uri.scheme = 'http' # is tcp otherwise
 Colonel.config.elasticsearch_uri = uri.to_s
 
-uri = URI(ENV['COLONELAPI_REDIS_1_PORT'])
+uri = URI(ENV['REDIS'] || ENV['COLONELAPI_REDIS_1_PORT'])
 redis_backend = Rugged::Redis::Backend.new(host: uri.host, port: uri.port)
 Colonel.config.rugged_backend = redis_backend
 

--- a/app.rb
+++ b/app.rb
@@ -4,11 +4,11 @@ require 'rugged-redis'
 require 'pry'
 require 'json'
 
-uri = URI(ENV['ELASTICSEARCH_URI'] || ENV['COLONELAPI_ELASTICSEARCH_1_PORT'])
+uri = URI(ENV['ELASTICSEARCH_URI'] || ENV['ELASTICSEARCH_PORT'])
 uri.scheme = 'http' # is tcp otherwise
 Colonel.config.elasticsearch_uri = uri.to_s
 
-uri = URI(ENV['REDIS_URI'] || ENV['COLONELAPI_REDIS_1_PORT'])
+uri = URI(ENV['REDIS_URI'] || ENV['REDIS_PORT'])
 redis_backend = Rugged::Redis::Backend.new(host: uri.host, port: uri.port)
 Colonel.config.rugged_backend = redis_backend
 


### PR DESCRIPTION
Added ELASTICSEARCH_URI & REDIS_URI for explicit setting of vars when choosing not to use docker for elasticsearch or redis.
